### PR TITLE
capacitive keys will only light up when pressed

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -74,4 +74,7 @@
          config to 7. -->
     <integer name="config_deviceHardwareWakeKeys">65</integer>
 
+     <!-- If enabled, capacitive keys will only light up when pressed.
+        Otherwise, the buttons will light up whenever the user interacts with the device -->
+    <bool name="config_buttonLightOnKeypressOnly">true</bool>
 </resources>


### PR DESCRIPTION
Stops capacitive keys from lighting up on screen touch